### PR TITLE
Feature/hostname-specific purge + translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.6
+
+- Add translations (French, Spanish, German, Italian)
+
 ## 1.3.5
 
 - Add hostname-specific cache purge option

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.3.5
+
+- Add hostname-specific cache purge option
+
+## 1.3.0
+
+- Prestashop 9 compatibility
+
 ## 1.2.2
 
 - Deprecated Minify settings removed

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 Cloudflare API features in Prestashop:
 
 - Clear Cloudflare Cache in the Prestashop admin
+- Hostname-specific cache purge (optional). If no hostname is configured, full cache purge is performed.
 
 ![Flush Cloudflare Cache](screenshot.png)
 
@@ -36,6 +37,7 @@ From the module manager, find the module and click on configure.
 | Field                | Description                                                                            | Required |
 |:---------------------|:---------------------------------------------------------------------------------------|----------|
 | Zone ID              | The website Zone ID                                                                    | Y        |
+| Hostname             | Specific hostname to purge (leave empty for full cache purge)                          | N        |
 | Authentication mode  | The authentication mode: API Token or Global API key                                   | Y        |
 | API Token *          | A valid token from your Cloudflare Account with permission on "Cache Purge" for "Zone" | Y        |
 | Global API Key       | The Cloudflare Global API key                                                          | Y        |

--- a/pixel_cloudflare.php
+++ b/pixel_cloudflare.php
@@ -20,7 +20,7 @@ class Pixel_cloudflare extends Module
     public function __construct()
     {
         $this->name = 'pixel_cloudflare';
-        $this->version = '1.3.5';
+        $this->version = '1.3.6';
         $this->author = 'Pixel Open';
         $this->tab = 'administration';
         $this->need_instance = 0;

--- a/pixel_cloudflare.php
+++ b/pixel_cloudflare.php
@@ -20,7 +20,7 @@ class Pixel_cloudflare extends Module
     public function __construct()
     {
         $this->name = 'pixel_cloudflare';
-        $this->version = '1.3.0';
+        $this->version = '1.3.5';
         $this->author = 'Pixel Open';
         $this->tab = 'administration';
         $this->need_instance = 0;
@@ -177,6 +177,18 @@ class Pixel_cloudflare extends Module
                 'name'     => 'CLOUDFLARE_ZONE_ID',
                 'size'     => 20,
                 'required' => true,
+            ],
+            'CLOUDFLARE_HOSTNAME' => [
+                'type'     => 'text',
+                'label'    => $this->trans('Hostname to purge (optional)', [], 'Modules.Pixelcloudflare.Admin'),
+                'name'     => 'CLOUDFLARE_HOSTNAME',
+                'size'     => 50,
+                'required' => false,
+                'desc'     => $this->trans(
+                    'Leave empty for full cache purge. Example: www.example.com',
+                    [],
+                    'Modules.Pixelcloudflare.Admin'
+                ),
             ],
             'CLOUDFLARE_API_AUTHENTICATION_MODE' => [
                 'type'     => 'select',

--- a/src/Helper/Config.php
+++ b/src/Helper/Config.php
@@ -71,4 +71,14 @@ class Config
     {
         return Configuration::get('CLOUDFLARE_ACCOUNT_EMAIL') ?: null;
     }
+
+    /**
+     * Retrieve Hostname to purge
+     *
+     * @return string|null
+     */
+    public function getHostname(): ?string
+    {
+        return Configuration::get('CLOUDFLARE_HOSTNAME') ?: null;
+    }
 }

--- a/src/Model/Api.php
+++ b/src/Model/Api.php
@@ -102,11 +102,14 @@ class Api
             return $this->internalError('The Zone ID parameter is missing in the module configuration');
         }
 
+        $hostname = $this->config->getHostname();
+        $body = $hostname ? ['hosts' => [$hostname]] : ['purge_everything' => true];
+
         try {
             return $this->execute(
                 'POST',
                 'zones/' . $this->config->getZoneId() . '/purge_cache',
-                ['purge_everything' => true]
+                $body
             );
         } catch (Throwable $throwable) {
             return $this->internalError($throwable->getMessage());

--- a/translations/ModulesPixelcloudflareAdmin.de-DE.xlf
+++ b/translations/ModulesPixelcloudflareAdmin.de-DE.xlf
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="pixel_cloudflare" source-language="en-US" target-language="de-DE" datatype="plaintext">
+    <body>
+      <trans-unit id="1" resname="Cloudflare">
+        <source>Cloudflare</source>
+        <target>Cloudflare</target>
+      </trans-unit>
+      <trans-unit id="2" resname="Cloudflare API features in Prestashop.">
+        <source>Cloudflare API features in Prestashop.</source>
+        <target>Cloudflare API-Funktionen in PrestaShop.</target>
+      </trans-unit>
+      <trans-unit id="3" resname="Cloudflare cache has been flushed">
+        <source>Cloudflare cache has been flushed</source>
+        <target>Cloudflare-Cache wurde geleert</target>
+      </trans-unit>
+      <trans-unit id="4" resname="Unable to clear Cloudflare cache">
+        <source>Unable to clear Cloudflare cache</source>
+        <target>Cloudflare-Cache konnte nicht geleert werden</target>
+      </trans-unit>
+      <trans-unit id="5" resname="Clear Cloudflare Cache">
+        <source>Clear Cloudflare Cache</source>
+        <target>Cloudflare-Cache leeren</target>
+      </trans-unit>
+      <trans-unit id="6" resname="Zone ID">
+        <source>Zone ID</source>
+        <target>Zonen-ID</target>
+      </trans-unit>
+      <trans-unit id="7" resname="Hostname to purge (optional)">
+        <source>Hostname to purge (optional)</source>
+        <target>Hostname zum Bereinigen (optional)</target>
+      </trans-unit>
+      <trans-unit id="8" resname="Leave empty for full cache purge. Example: www.example.com">
+        <source>Leave empty for full cache purge. Example: www.example.com</source>
+        <target>Leer lassen für vollständige Cache-Bereinigung. Beispiel: www.example.com</target>
+      </trans-unit>
+      <trans-unit id="9" resname="Authentication mode">
+        <source>Authentication mode</source>
+        <target>Authentifizierungsmodus</target>
+      </trans-unit>
+      <trans-unit id="10" resname="API Token">
+        <source>API Token</source>
+        <target>API-Token</target>
+      </trans-unit>
+      <trans-unit id="11" resname="Global API Key">
+        <source>Global API Key</source>
+        <target>Globaler API-Schlüssel</target>
+      </trans-unit>
+      <trans-unit id="12" resname="A valid token from your Cloudflare Account with permission on &quot;Cache Purge&quot; for &quot;Zone&quot;.">
+        <source>A valid token from your Cloudflare Account with permission on "Cache Purge" for "Zone".</source>
+        <target>Ein gültiges Token aus Ihrem Cloudflare-Konto mit der Berechtigung "Cache Purge" für "Zone".</target>
+      </trans-unit>
+      <trans-unit id="13" resname="Account Email">
+        <source>Account Email</source>
+        <target>Konto-E-Mail</target>
+      </trans-unit>
+      <trans-unit id="14" resname="%field% is empty">
+        <source>%field% is empty</source>
+        <target>Das Feld %field% ist leer</target>
+      </trans-unit>
+      <trans-unit id="15" resname="Settings updated">
+        <source>Settings updated</source>
+        <target>Einstellungen aktualisiert</target>
+      </trans-unit>
+      <trans-unit id="16" resname="Settings">
+        <source>Settings</source>
+        <target>Einstellungen</target>
+      </trans-unit>
+      <trans-unit id="17" resname="Save">
+        <source>Save</source>
+        <target>Speichern</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/translations/ModulesPixelcloudflareAdmin.es-ES.xlf
+++ b/translations/ModulesPixelcloudflareAdmin.es-ES.xlf
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="pixel_cloudflare" source-language="en-US" target-language="es-ES" datatype="plaintext">
+    <body>
+      <trans-unit id="1" resname="Cloudflare">
+        <source>Cloudflare</source>
+        <target>Cloudflare</target>
+      </trans-unit>
+      <trans-unit id="2" resname="Cloudflare API features in Prestashop.">
+        <source>Cloudflare API features in Prestashop.</source>
+        <target>Funcionalidades de la API de Cloudflare en PrestaShop.</target>
+      </trans-unit>
+      <trans-unit id="3" resname="Cloudflare cache has been flushed">
+        <source>Cloudflare cache has been flushed</source>
+        <target>La caché de Cloudflare ha sido vaciada</target>
+      </trans-unit>
+      <trans-unit id="4" resname="Unable to clear Cloudflare cache">
+        <source>Unable to clear Cloudflare cache</source>
+        <target>No se puede vaciar la caché de Cloudflare</target>
+      </trans-unit>
+      <trans-unit id="5" resname="Clear Cloudflare Cache">
+        <source>Clear Cloudflare Cache</source>
+        <target>Vaciar caché de Cloudflare</target>
+      </trans-unit>
+      <trans-unit id="6" resname="Zone ID">
+        <source>Zone ID</source>
+        <target>ID de zona</target>
+      </trans-unit>
+      <trans-unit id="7" resname="Hostname to purge (optional)">
+        <source>Hostname to purge (optional)</source>
+        <target>Hostname a purgar (opcional)</target>
+      </trans-unit>
+      <trans-unit id="8" resname="Leave empty for full cache purge. Example: www.example.com">
+        <source>Leave empty for full cache purge. Example: www.example.com</source>
+        <target>Dejar vacío para purga completa de caché. Ejemplo: www.example.com</target>
+      </trans-unit>
+      <trans-unit id="9" resname="Authentication mode">
+        <source>Authentication mode</source>
+        <target>Modo de autenticación</target>
+      </trans-unit>
+      <trans-unit id="10" resname="API Token">
+        <source>API Token</source>
+        <target>Token de API</target>
+      </trans-unit>
+      <trans-unit id="11" resname="Global API Key">
+        <source>Global API Key</source>
+        <target>Clave API global</target>
+      </trans-unit>
+      <trans-unit id="12" resname="A valid token from your Cloudflare Account with permission on &quot;Cache Purge&quot; for &quot;Zone&quot;.">
+        <source>A valid token from your Cloudflare Account with permission on "Cache Purge" for "Zone".</source>
+        <target>Un token válido de tu cuenta Cloudflare con permiso de "Cache Purge" para la "Zone".</target>
+      </trans-unit>
+      <trans-unit id="13" resname="Account Email">
+        <source>Account Email</source>
+        <target>Email de la cuenta</target>
+      </trans-unit>
+      <trans-unit id="14" resname="%field% is empty">
+        <source>%field% is empty</source>
+        <target>El campo %field% está vacío</target>
+      </trans-unit>
+      <trans-unit id="15" resname="Settings updated">
+        <source>Settings updated</source>
+        <target>Configuración actualizada</target>
+      </trans-unit>
+      <trans-unit id="16" resname="Settings">
+        <source>Settings</source>
+        <target>Configuración</target>
+      </trans-unit>
+      <trans-unit id="17" resname="Save">
+        <source>Save</source>
+        <target>Guardar</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/translations/ModulesPixelcloudflareAdmin.fr-FR.xlf
+++ b/translations/ModulesPixelcloudflareAdmin.fr-FR.xlf
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="pixel_cloudflare" source-language="en-US" target-language="fr-FR" datatype="plaintext">
+    <body>
+      <trans-unit id="1" resname="Cloudflare">
+        <source>Cloudflare</source>
+        <target>Cloudflare</target>
+      </trans-unit>
+      <trans-unit id="2" resname="Cloudflare API features in Prestashop.">
+        <source>Cloudflare API features in Prestashop.</source>
+        <target>Fonctionnalités de l'API Cloudflare dans PrestaShop.</target>
+      </trans-unit>
+      <trans-unit id="3" resname="Cloudflare cache has been flushed">
+        <source>Cloudflare cache has been flushed</source>
+        <target>Le cache Cloudflare a été vidé</target>
+      </trans-unit>
+      <trans-unit id="4" resname="Unable to clear Cloudflare cache">
+        <source>Unable to clear Cloudflare cache</source>
+        <target>Impossible de vider le cache Cloudflare</target>
+      </trans-unit>
+      <trans-unit id="5" resname="Clear Cloudflare Cache">
+        <source>Clear Cloudflare Cache</source>
+        <target>Vider le cache Cloudflare</target>
+      </trans-unit>
+      <trans-unit id="6" resname="Zone ID">
+        <source>Zone ID</source>
+        <target>ID de zone</target>
+      </trans-unit>
+      <trans-unit id="7" resname="Hostname to purge (optional)">
+        <source>Hostname to purge (optional)</source>
+        <target>Hostname à purger (optionnel)</target>
+      </trans-unit>
+      <trans-unit id="8" resname="Leave empty for full cache purge. Example: www.example.com">
+        <source>Leave empty for full cache purge. Example: www.example.com</source>
+        <target>Laisser vide pour une purge complète du cache. Exemple : www.example.com</target>
+      </trans-unit>
+      <trans-unit id="9" resname="Authentication mode">
+        <source>Authentication mode</source>
+        <target>Mode d'authentification</target>
+      </trans-unit>
+      <trans-unit id="10" resname="API Token">
+        <source>API Token</source>
+        <target>Token API</target>
+      </trans-unit>
+      <trans-unit id="11" resname="Global API Key">
+        <source>Global API Key</source>
+        <target>Clé API globale</target>
+      </trans-unit>
+      <trans-unit id="12" resname="A valid token from your Cloudflare Account with permission on &quot;Cache Purge&quot; for &quot;Zone&quot;.">
+        <source>A valid token from your Cloudflare Account with permission on "Cache Purge" for "Zone".</source>
+        <target>Un token valide de votre compte Cloudflare avec la permission "Cache Purge" pour la "Zone".</target>
+      </trans-unit>
+      <trans-unit id="13" resname="Account Email">
+        <source>Account Email</source>
+        <target>Email du compte</target>
+      </trans-unit>
+      <trans-unit id="14" resname="%field% is empty">
+        <source>%field% is empty</source>
+        <target>Le champ %field% est vide</target>
+      </trans-unit>
+      <trans-unit id="15" resname="Settings updated">
+        <source>Settings updated</source>
+        <target>Paramètres mis à jour</target>
+      </trans-unit>
+      <trans-unit id="16" resname="Settings">
+        <source>Settings</source>
+        <target>Paramètres</target>
+      </trans-unit>
+      <trans-unit id="17" resname="Save">
+        <source>Save</source>
+        <target>Enregistrer</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/translations/ModulesPixelcloudflareAdmin.it-IT.xlf
+++ b/translations/ModulesPixelcloudflareAdmin.it-IT.xlf
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="pixel_cloudflare" source-language="en-US" target-language="it-IT" datatype="plaintext">
+    <body>
+      <trans-unit id="1" resname="Cloudflare">
+        <source>Cloudflare</source>
+        <target>Cloudflare</target>
+      </trans-unit>
+      <trans-unit id="2" resname="Cloudflare API features in Prestashop.">
+        <source>Cloudflare API features in Prestashop.</source>
+        <target>Funzionalità API Cloudflare in PrestaShop.</target>
+      </trans-unit>
+      <trans-unit id="3" resname="Cloudflare cache has been flushed">
+        <source>Cloudflare cache has been flushed</source>
+        <target>La cache di Cloudflare è stata svuotata</target>
+      </trans-unit>
+      <trans-unit id="4" resname="Unable to clear Cloudflare cache">
+        <source>Unable to clear Cloudflare cache</source>
+        <target>Impossibile svuotare la cache di Cloudflare</target>
+      </trans-unit>
+      <trans-unit id="5" resname="Clear Cloudflare Cache">
+        <source>Clear Cloudflare Cache</source>
+        <target>Svuota cache Cloudflare</target>
+      </trans-unit>
+      <trans-unit id="6" resname="Zone ID">
+        <source>Zone ID</source>
+        <target>ID zona</target>
+      </trans-unit>
+      <trans-unit id="7" resname="Hostname to purge (optional)">
+        <source>Hostname to purge (optional)</source>
+        <target>Hostname da purgare (opzionale)</target>
+      </trans-unit>
+      <trans-unit id="8" resname="Leave empty for full cache purge. Example: www.example.com">
+        <source>Leave empty for full cache purge. Example: www.example.com</source>
+        <target>Lasciare vuoto per la purga completa della cache. Esempio: www.example.com</target>
+      </trans-unit>
+      <trans-unit id="9" resname="Authentication mode">
+        <source>Authentication mode</source>
+        <target>Modalità di autenticazione</target>
+      </trans-unit>
+      <trans-unit id="10" resname="API Token">
+        <source>API Token</source>
+        <target>Token API</target>
+      </trans-unit>
+      <trans-unit id="11" resname="Global API Key">
+        <source>Global API Key</source>
+        <target>Chiave API globale</target>
+      </trans-unit>
+      <trans-unit id="12" resname="A valid token from your Cloudflare Account with permission on &quot;Cache Purge&quot; for &quot;Zone&quot;.">
+        <source>A valid token from your Cloudflare Account with permission on "Cache Purge" for "Zone".</source>
+        <target>Un token valido dal tuo account Cloudflare con permesso "Cache Purge" per la "Zone".</target>
+      </trans-unit>
+      <trans-unit id="13" resname="Account Email">
+        <source>Account Email</source>
+        <target>Email account</target>
+      </trans-unit>
+      <trans-unit id="14" resname="%field% is empty">
+        <source>%field% is empty</source>
+        <target>Il campo %field% è vuoto</target>
+      </trans-unit>
+      <trans-unit id="15" resname="Settings updated">
+        <source>Settings updated</source>
+        <target>Impostazioni aggiornate</target>
+      </trans-unit>
+      <trans-unit id="16" resname="Settings">
+        <source>Settings</source>
+        <target>Impostazioni</target>
+      </trans-unit>
+      <trans-unit id="17" resname="Save">
+        <source>Save</source>
+        <target>Salva</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>


### PR DESCRIPTION
## Summary

This PR adds two new features to the Cloudflare module:

### Hostname-specific cache purge
- New optional configuration field `Hostname to purge`
- When configured, only the specified hostname cache is purged instead of the entire zone
- **Fallback behavior**: if the field is left empty, full cache purge is performed (backward compatible)

### Translations
- French (fr-FR)
- Spanish (es-ES)
- German (de-DE)
- Italian (it-IT)

## Changes

| File | Description |
|------|-------------|
| `src/Helper/Config.php` | Add `getHostname()` method |
| `src/Model/Api.php` | Modify `clearCache()` to use `hosts[]` API parameter |
| `pixel_cloudflare.php` | Add hostname config field, bump version to 1.3.6 |
| `CHANGELOG.md` | Add 1.3.5 and 1.3.6 entries |
| `README.md` | Document new feature |
| `translations/*.xlf` | Add XLIFF translation files |

## Test plan

- [ ] Install module and configure hostname → verify cache purge targets only that hostname
- [ ] Leave hostname empty → verify full cache purge (purge_everything)
- [ ] Switch PrestaShop language to French → verify translations appear
